### PR TITLE
Exclude dependabot PRs from changelog

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,0 +1,6 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - dependabot[bot]


### PR DESCRIPTION
Dependabot commits add a lot of noise to the release notes - we only want user-facing changes in there. This config skips dependabot PRs when creating the changelog.
